### PR TITLE
DEV-2997 Fix compatibility with new build tools.

### DIFF
--- a/src/getMessagesFromSource.js
+++ b/src/getMessagesFromSource.js
@@ -93,7 +93,7 @@ module.exports = function getMessagesFromSource (source, packageName, fileName, 
 
 			const binding = path.scope.getBinding('t');
 			const sourcePath = getImportSourcePath(binding);
-			if (sourcePath !== 'fontoxml-localization/t' && sourcePath !== 'fontoxml-localization/src/t') {
+			if (!sourcePath || !sourcePath.match(/^fontoxml-localization\/(src\/)?t(\.js)?$/g)) {
 				return;
 			}
 


### PR DESCRIPTION
This fixes a compatibility issue with the new build tools.

It matches:
fontoxml-localization-tools/t
fontoxml-localization-tools/src/t
fontoxml-localization-tools/t.js
fontoxml-localization-tools/src/t.js